### PR TITLE
Fixed issue with extension of protocol ISQLParameter where if the dat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-*
 .hgignore
 .hg/
+/.idea
+*.iml

--- a/src/mpg/data.clj
+++ b/src/mpg/data.clj
@@ -44,7 +44,7 @@
   (extend-protocol j/ISQLParameter
     IPersistentMap
     (set-parameter [v ^java.sql.PreparedStatement stmt ^long idx]
-      (case (try (u/pg-param-type stmt idx) (catch ExceptionInfo e default-map))
+      (case (try (u/pg-param-type stmt idx) (catch ExceptionInfo e (name default-map)))
         "json"   (.setObject stmt idx (u/pg-json v))
         "jsonb"  (.setObject stmt idx (u/pg-json v))
         "citext" (.setObject stmt idx (str v))


### PR DESCRIPTION
…atype could not be determined when resolving an IPersistentMap parameter, no match was likely to be found unless "default-map" was set to a string instead of a keyword.

Also added Intellij / Cursive project files to the .gitignore file.
