### PR TITLE
Refactor tests to clean up massively

### DIFF
--- a/test/mpg/core_test.clj
+++ b/test/mpg/core_test.clj
@@ -7,6 +7,7 @@
            [org.postgresql.util PGobject]))
 
 (mpg/patch)
+
 ;; Allow the user to specify connection parameters on the command line
 (def pg
   (as-> {:subprotocol "postgresql"
@@ -21,6 +22,11 @@
 
 (def conn (sql/get-connection pg))
 
+(defn random-byte-array [size]
+  (let [a (byte-array size)]
+    (->> a .nextBytes (doto (java.util.Random.)))
+    a))
+
 (defn roundtrip-prepared [type val]
   (-> (as-> (str "select (? :: " type ") as result") $
         (sql/prepare-statement conn $)
@@ -32,54 +38,36 @@
         (sql/query pg [sql val]))
       first :result))
 
+(defn roundtrip-test
+  ([title v types]
+   (roundtrip-test title v types identity))
+  ([title v types printer]
+   (testing title
+     (let [v2 (printer v)]
+       (doseq [t types]
+         (is (= v2
+                (printer (roundtrip-unprepared t v))
+                (printer (roundtrip-prepared   t v))
+                ;; repeat because of issue #17
+                (printer (roundtrip-unprepared t v))
+                (printer (roundtrip-prepared   t v)))))))))
+
 (deftest data
   (let [v1 {:a [{:b "c"}]}
         v2 [{:b [4 5 6]}]
-        v3 {"a" "123" "b" "456"}] ; jdbc+hstore cannot has such rich delights as "numbers"
-    (testing "roundtripping complex maps through json"
-      (is (= v1
-             (roundtrip-unprepared "json"  v1)
-             (roundtrip-prepared   "json"  v1)
-             (roundtrip-unprepared "jsonb" v1)
-             (roundtrip-prepared   "jsonb" v1))))
-    (testing "roundtripping complex vectors through json"
-      (is (= v2
-             (roundtrip-unprepared "json"  v2)
-             (roundtrip-unprepared "jsonb" v2)
-             (roundtrip-prepared   "json"  v2)
-             (roundtrip-prepared   "jsonb" v2))))
-    (testing "roundtripping simple maps through hstore"
-      (is (= v3
-             (roundtrip-unprepared "hstore"  v3)
-             (roundtrip-prepared   "hstore"  v3))))))
-
-(deftest arrays
-  (testing "vector roundtrips through array"
-    (let [v [2 4 8]]
-      (is (= v
-             (roundtrip-unprepared "int[]" v)
-             (roundtrip-prepared   "int[]" v)
-             ;; should work fine second time
-             (roundtrip-prepared   "int[]" v))))))
+        v3 {"a" "123" "b" "456"} ; jdbc+hstore cannot has such rich delights as "numbers"
+        v4 [2 4 8]
+        v5 "example text"
+        v6 (random-byte-array 32)]
+    (roundtrip-test "maps <-> json"        v1 ["json" "jsonb"])
+    (roundtrip-test "vector <-> json"      v2 ["json" "jsonb"])
+    (roundtrip-test "map <-> hstore"       v3 ["hstore"])
+    (roundtrip-test "vector <-> array"     v4 ["int[]"])
+    (roundtrip-test "string <-> citext"    v5 ["citext"])
+    (roundtrip-test "byte-array <-> bytea" v6 ["bytea"] #(String. %))))
 
 (deftest datetime
-  (testing "LocalDate roundtrips through date"
-    (let [v (LocalDate/now)]
-      (is (= v
-             (roundtrip-unprepared "date" v)
-             (roundtrip-prepared   "date" v)))))
-  (testing "ZonedDateTime roundtrips through timestamp/tz"
-    (let [v (ZonedDateTime/now (ZoneId/of "UTC"))]
-      (is (= v
-             (roundtrip-unprepared "timestamp" v)
-             (roundtrip-prepared   "timestamp" v)))
-      (is (= v
-             (roundtrip-unprepared "timestamptz" v)
-             (roundtrip-prepared   "timestamptz" v))))))
-
-(deftest citext
-  (testing "citext should be treated as string type"
-    (let [v "some example text"]
-      (is (= v
-             (roundtrip-prepared "citext" v)
-             (roundtrip-unprepared "citext" v))))))
+  (let [now-loc (LocalDate/now)
+        now-utc (ZonedDateTime/now (ZoneId/of "UTC"))]
+    (roundtrip-test "LocalDate <-> date"          now-loc ["date"])
+    (roundtrip-test "ZonedDateTime <-> timestamp" now-utc ["timestamp" "timestamptz"])))


### PR DESCRIPTION
The new code is more readable by far and weighs in even shorter, 12 lines to be exact.

As per issue #16, bytea "just works", so i have included the test for this as well.
