### PR TITLE
Added unidirectional casts for j.u.Date, j.s.Timestamp and j.nio.ByteBuffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,12 @@ script: lein test
 branches:
   only:
     - master
-    - kentnl
-env:
-  - UTRECHT_TEST_DB="utrecht_test"
 addons:
   postgresql: "9.4"
 services:
   - postgresql
 before_script:
-  - psql -c 'create database sanity_test;' -U postgres
+  - psql -c 'create database mpg_test;' -U postgres
   - psql -d sanity_test -c 'create extension hstore;' -U postgres
   - psql -d sanity_test -c 'create extension citext;' -U postgres
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database mpg_test;' -U postgres
-  - psql -d sanity_test -c 'create extension hstore;' -U postgres
-  - psql -d sanity_test -c 'create extension citext;' -U postgres
+  - psql -d mpg_test -c 'create extension hstore;' -U postgres
+  - psql -d mpg_test -c 'create extension citext;' -U postgres
 jdk:
   - oraclejdk8
 #  - openjdk7 # tests fail - probably running out of memory or disk

--- a/README.md
+++ b/README.md
@@ -8,8 +8,16 @@ Handles the following:
 - `DATE` <-> `java.time.LocalDate`
 - `TIMESTAMP/TIMESTAMPTZ` <-> `java.time.ZonedDateTime`
 - `JSON/JSONB` <-> clojure map/vector
-- `ARRAY` (e.g. `int[]`)<-> clojure vector
+- `ARRAY` (e.g. `int[]`) <-> clojure vector
+- `BYTEA` <-> byte array
 - `HSTORE` <-> clojure map (limited support - jdbc stringifies all contents)
+
+Can also insert (but not retrieve) the following types:
+
+- `java.util.Date` -> `DATE/TIMESTAMP/TIMESTAMPTZ`
+- `java.sql.Timestamp` -> `DATE/TIMESTAMP/TIMESTAMPTZ`
+- `java.nio.ByteBuffer` -> `BYTEA` 
+
 
 [![Build Status](https://travis-ci.org/mpg-project/mpg.svg?branch=master)](https://travis-ci.org/mpg-project/mpg)
 

--- a/src/mpg/datetime.clj
+++ b/src/mpg/datetime.clj
@@ -3,7 +3,8 @@
             [mpg.util :as u])
   (:import [java.time Instant LocalDate LocalDateTime ZonedDateTime ZoneId]
            [java.time.temporal ChronoField]
-           [java.sql Date Timestamp PreparedStatement]))
+           [java.sql Date Timestamp PreparedStatement]
+           [java.util Calendar]))
 
 (defn get-zone
   "Returns the zone named, which may be a keyword or string, e.g. :UTC"
@@ -21,6 +22,24 @@
       (.withZoneSameInstant local)
       .toLocalDateTime
       Timestamp/valueOf))
+
+(defn truncate-date [^java.util.Date d]
+  (-> (doto (Calendar/getInstance)
+        (.setTime d)
+        (.set Calendar/HOUR_OF_DAY 0)
+        (.set Calendar/MINUTE 0)
+        (.set Calendar/SECOND 0)
+        (.set Calendar/MILLISECOND 0))
+      .getTimeInMillis
+      Date.))
+    
+
+(defn localdate->date [^LocalDate ld]
+  (-> ld
+      (.atStartOfDay (ZoneId/systemDefault))
+      .toInstant
+      Date/from))
+
 (defn patch
   "Installs conversion hooks for various java.time types
    args: []"
@@ -32,12 +51,31 @@
     Timestamp
     (result-set-read-column [^Timestamp v _ _]
       (-> v .toInstant (.atZone utc))))
+  (extend-protocol j/ISQLValue
+    java.util.Date
+    (sql-value [value]
+      (Date. (.getTime value)))
+    LocalDate
+    (sql-value [value]
+      (localdate->date value))
+    ZonedDateTime
+    (sql-value [value]
+      (zoneddatetime->timestamp value)))
   (extend-protocol j/ISQLParameter
+    java.util.Date
+    (set-parameter [^java.util.Date v ^PreparedStatement stmt ^long idx]
+      (.setObject stmt idx
+        (case (u/pg-param-type stmt idx)
+          "date" (Date. (.getTime v))
+          "timestamp" (Timestamp. (.getTime v))
+          "timestamptz" (Timestamp. (.getTime v)))))
     LocalDate
     (set-parameter [^LocalDate v ^PreparedStatement stmt ^long idx]
       (.setObject stmt idx
         (case (u/pg-param-type stmt idx)
-          "date" (Date/valueOf v))))
+          "date"        (Date/valueOf v)
+          "timestamp"   (Date/valueOf v)
+          "timestamptz" (Date/valueOf v))))
     ZonedDateTime
     (set-parameter [^ZonedDateTime v ^PreparedStatement stmt ^long idx]
       (let [t (u/pg-param-type stmt idx)]

--- a/test/mpg/core_test.clj
+++ b/test/mpg/core_test.clj
@@ -2,17 +2,43 @@
   (:require [clojure.test :refer :all]
             [clojure.java.jdbc :as sql]
             [environ.core :refer [env]]
-            [mpg.core :as mpg])
-  (:import [java.time LocalDate ZonedDateTime ZoneId]
+            [mpg.core :as mpg]
+            [mpg.data :as d]
+            [mpg.datetime :as dt])
+  (:import [java.nio ByteBuffer]
+           [java.sql Timestamp]
+           [java.time LocalDate ZonedDateTime ZoneId]
            [org.postgresql.util PGobject]))
 
 (mpg/patch)
+
+(defn to-byte-string [thing]
+  (cond (instance? (Class/forName "[B") thing) (String. ^bytes thing)
+        (instance? ByteBuffer thing) (String. ^bytes (d/bytebuf->array thing))
+        :else (-> (str "WTF is this? " thing " " (type thing))
+                  (ex-info {:got thing})
+                  throw)))
+
+(defn to-ts [thing]
+  (cond (instance? Timestamp thing) thing
+        (instance? java.util.Date thing) (Timestamp. (.getTime ^java.util.Date thing))
+        (instance? ZonedDateTime thing) (dt/zoneddatetime->timestamp thing)
+        :else (-> (str "WTF is this? " thing " " (type thing))
+                  (ex-info {:got thing})
+                  throw)))
+
+(defn to-date [thing]
+  (cond (instance? java.util.Date thing) (dt/truncate-date thing)
+        (instance? LocalDate thing) (dt/localdate->date thing)
+        :else (-> (str "WTF is this? " thing " " (type thing))
+                  (ex-info {:got thing})
+                  throw)))
 
 ;; Allow the user to specify connection parameters on the command line
 (def pg
   (as-> {:subprotocol "postgresql"
          :subname (or (env :mpg-test-db-uri)
-                      "//127.0.0.1:5432/sanity_test")} $
+                      "//127.0.0.1:5432/mpg_test")} $
     (if-let [user (env :mpg-test-db-user)]
       (assoc $ :user user)
       $)
@@ -56,7 +82,7 @@
                 (printer (roundtrip-unprepared t v))
                 (printer (roundtrip-prepared   t v)))))))))
 
-(deftest data
+(deftest data-bidirectional
   (let [v1 {:a [{:b "c"}]}
         v2 [{:b [4 5 6]}]
         v3 {"a" "123" "b" "456"} ; jdbc+hstore cannot has such rich delights as "numbers"
@@ -68,12 +94,27 @@
     (roundtrip-test "map <-> hstore"       v3 ["hstore"])
     (roundtrip-test "vector <-> array"     v4 ["int[]"])
     (roundtrip-test "string <-> citext"    v5 ["citext"])
-    (roundtrip-test "byte-array <-> bytea" v6 ["bytea"] #(String. %))))
+    (roundtrip-test "byte-array <-> bytea" v6 ["bytea"] #(String. ^bytes %))))
 
-(deftest datetime
+(deftest data-unidirectional
+  (let [bytes (random-byte-array 32)
+        bb (doto (ByteBuffer/allocate 32)
+             (.put ^bytes bytes))]
+    (roundtrip-test "Bytebuffer -> bytea" bb ["bytea"] to-byte-string)))
+
+(deftest datetime-bidirectional
   (let [now-loc (LocalDate/now)
         now-utc (ZonedDateTime/now (ZoneId/of "UTC"))]
     (roundtrip-test "LocalDate <-> date"          now-loc ["date"])
     (roundtrip-test "ZonedDateTime <-> timestamp" now-utc ["timestamp" "timestamptz"])))
+
+(deftest datetime-unidirectional
+  (let [now-jud (java.util.Date.)
+        now-jsts  (java.sql.Timestamp. (.getTime now-jud))]
+    (roundtrip-test "j.u.Date -> date" now-jud ["date"] to-date)
+    (roundtrip-test "j.u.Date -> timestamp" now-jud ["timestamp" "timestamptz"] to-ts)
+    (roundtrip-test "j.s.Timestamp -> date" now-jsts ["date"] to-date)
+    (roundtrip-test "j.s.Timestamp -> timestamp" now-jsts ["timestamp" "timestamptz"] to-ts)))
+    
 
 (prepare-db)


### PR DESCRIPTION
Also tests were refactored slightly to accommodate them.

While I was at it, I picked up a few j.u.Date-related potential bugs. I really didn't want to read the postgres jdbc driver to see if it was one of the vulnerable ones because last time I barely escaped with my sanity intract.

Also the test suite default database name has changed. Sorry about that.
